### PR TITLE
avoid obstale

### DIFF
--- a/orne_box_bringup/launch/include/mirror_lidar.launch.py
+++ b/orne_box_bringup/launch/include/mirror_lidar.launch.py
@@ -92,7 +92,7 @@ def generate_launch_description():
     return LaunchDescription([
         DeclareLaunchArgument('auto_start', default_value='true'),
         DeclareLaunchArgument('node_name', default_value='urg_node2'),
-        DeclareLaunchArgument('scan_topic_name', default_value='scan'),
+        DeclareLaunchArgument('scan_topic_name', default_value='mirror_scan'),
         lifecycle_node,
         urg_node2_node_configure_event_handler,
         urg_node2_node_activate_event_handler,

--- a/orne_box_navigation_executor/config/params/nav2_params.yaml
+++ b/orne_box_navigation_executor/config/params/nav2_params.yaml
@@ -239,11 +239,18 @@ local_costmap:
       obstacle_layer:
         plugin: "nav2_costmap_2d::ObstacleLayer"
         enabled: True
-        observation_sources: scan
+        observation_sources: scan, mirror_scan
         scan:
           # topic: /scan
           topic: /scan
           max_obstacle_height: 2.0
+          clearing: True
+          marking: True
+          data_type: "LaserScan"
+        mirror_scan:
+          topic: /mirror_scan
+          max_obstacle_height: 1.0
+          min_obstacle_height: 0.05
           clearing: True
           marking: True
           data_type: "LaserScan"
@@ -308,11 +315,22 @@ global_costmap:
       obstacle_layer:
         plugin: "nav2_costmap_2d::ObstacleLayer"
         enabled: True
-        observation_sources: scan
+        observation_sources: scan, mirror_scan
         scan:
           # topic: /scan
           topic: /scan
           max_obstacle_height: 2.0
+          clearing: True
+          marking: True
+          data_type: "LaserScan"
+          raytrace_max_range: 3.0
+          raytrace_min_range: 0.0
+          obstacle_max_range: 2.5
+          obstacle_min_range: 0.0
+        mirror_scan:
+          topic: /mirror_scan
+          max_obstacle_height: 2.0
+          min_obstacle_height: 0.05
           clearing: True
           marking: True
           data_type: "LaserScan"


### PR DESCRIPTION
障害物回避も含めたミラー搭載URGのブランチ

`clearing: False`

の方が地図に障害物が残るので確実な回避が見込めるが，誤認識や動的な障害物のことを考えるとTrueの方が安全である．
こちらではまずは`True`にしている．

時間が来たら削除されるなどの機能が実装できればそれが一番望ましいと考える．
